### PR TITLE
added code owners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,16 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, @onepoint-southbelgium and @pivielti
+# will be requested for review when someone opens a pull request.
+*       @onepoint-southbelgium @pivielti
+
+# Order is important; the last matching pattern takes the most precedence.
+# When someone opens a pull request that only modifies JS files, only @pivielti
+# and not @onepoint-southbelgium owner will be requested for a review.
+*.js    @pivielti
+
+# You can also use email addresses if you prefer. They'll be used to look up
+# users just like we do for commit author emails.
+docs/*  p.vanlinthout@groupeonepoint.com


### PR DESCRIPTION
Use a CODEOWNERS file to define individuals or teams that are responsible for code in a repository.
Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. When someone with admin permissions has enabled required reviews, they can optionally require approval from a code owner.